### PR TITLE
ci: modernize test matrix and publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,23 +11,27 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    
+    - uses: actions/checkout@v4
+
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
-    
-    - name: Install dependencies
+        python-version: '3.12'
+
+    - name: Install build tooling
       run: |
         python -m pip install --upgrade pip
         pip install build twine
-    
+
     - name: Build package
       run: python -m build
-    
+
+    - name: Check distribution metadata
+      run: twine check dist/*
+
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
+        skip-existing: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Minimal Tests
+name: Tests
 
 on:
   push:
@@ -9,27 +9,36 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+
     steps:
     - uses: actions/checkout@v4
-    
-    - name: Set up Python
-      uses: actions/setup-python@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
-    
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -e ".[dev]"
-    
-    - name: Quick lint check (critical errors only)
+
+    - name: Lint (critical errors)
       run: |
         flake8 langchain_iointelligence/ --select=E9,F63,F7,F82 --show-source
-    
+
+    - name: Lint (style, non-blocking)
+      run: |
+        flake8 langchain_iointelligence/ tests/ || true
+
     - name: Run tests
       env:
         IO_API_KEY: test_api_key_for_github_actions
         IO_API_URL: https://test.example.com/v1/chat/completions
       run: |
-        pytest tests/test_llm.py tests/test_chat.py -v
+        pytest -v


### PR DESCRIPTION
## Summary

Follow-up to #3 (it deferred the workflow changes because the pushing account needed the `workflow` token scope). Modernizes both CI workflows.

### `test.yml`
- Run the **full** pytest suite (was only `test_llm.py` + `test_chat.py`) across a **Python 3.9–3.13 matrix** (`fail-fast: false`).
- `actions/checkout@v4`, `actions/setup-python@v5`, with `cache: 'pip'`.
- Keep the critical-error flake8 gate; add a non-blocking style lint pass.

### `publish.yml`
- Update actions and build Python to 3.12.
- Run `twine check dist/*` before publishing.
- Set `skip-existing: true` so re-tagging an already-published version no longer fails the job (this is exactly what made the v0.3.0 tag/release runs go red, since 0.3.0 was published manually first).

## Notes
- No package code changes; CI only.
- Locally: 56 tests pass and both workflow files are valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)