### PR TITLE
Add tool/function calling and structured output (0.4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@
 | ✅ **Error Handling** | **Production Ready** | Comprehensive error classification and retry logic |
 | ✅ **Token Usage** | **Fully Supported** | `response.usage_metadata` access (0.2.0+) |
 | ✅ **Vision/Multimodal** | **Supported** | Image input via `vision_message()` on vision models (0.3.0+) |
-| ⚠️ **Streaming** | **Basic Support** | SSE token chunks; usage-at-end *coming soon* |
-| ❌ **Function/Tool Calling** | **Not Supported** | Planned for future release |
+| ✅ **Function/Tool Calling** | **Supported** | `bind_tools()` with tool-call parsing + streaming (0.4.0+) |
+| ✅ **Structured Output** | **Supported** | `with_structured_output()` — function calling / json_schema / json_mode (0.4.0+) |
+| ⚠️ **Streaming** | **Basic Support** | SSE token + tool-call chunks; usage-at-end *coming soon* |
 | ❌ **Embeddings** | **Not Supported** | Use dedicated embedding providers |
 
 > **Note**: Non-core message roles default to `user`. Usage metadata always includes all required fields (`input_tokens`, `output_tokens`, `total_tokens`) with defaults of 0 when data unavailable.
@@ -157,6 +158,64 @@ You can also build content blocks manually with `image_content_block()` or
 encode a file yourself with `encode_image_to_data_url()`. Any LangChain-standard
 multimodal `HumanMessage` (a list of `text` / `image_url` content blocks) is
 passed through unchanged, so existing OpenAI-style vision code works as-is.
+
+### **Tool / Function Calling** 🛠️
+
+Bind tools with `bind_tools()`; tool calls are parsed into the standard
+`AIMessage.tool_calls`, so the model drops straight into LangGraph / agent
+workflows. Works with `@tool` functions, Pydantic models, `BaseTool`
+instances, plain functions, or raw OpenAI tool dicts.
+
+```python
+from langchain_core.tools import tool
+from langchain_iointelligence import IOIntelligenceChatModel
+
+@tool
+def get_weather(location: str) -> str:
+    """Get the current weather for a location."""
+    return f"It's sunny in {location}."
+
+chat = IOIntelligenceChatModel(model="meta-llama/Llama-3.3-70B-Instruct")
+llm_with_tools = chat.bind_tools([get_weather])
+
+ai_msg = llm_with_tools.invoke("What's the weather in Tokyo?")
+for call in ai_msg.tool_calls:
+    print(call["name"], call["args"])   # get_weather {'location': 'Tokyo'}
+```
+
+`tool_choice` accepts `"auto"` / `"none"` / `"required"` (or `True`), a specific
+tool name, or an explicit OpenAI `tool_choice` dict. Multi-turn tool
+conversations (assistant `tool_calls` → `ToolMessage` results) round-trip
+correctly, and tool-call deltas are also surfaced when streaming.
+
+### **Structured Output** 🧱
+
+`with_structured_output()` returns a runnable that parses the response into your
+schema (a Pydantic model, TypedDict, or JSON-schema dict).
+
+```python
+from pydantic import BaseModel, Field
+from langchain_iointelligence import IOIntelligenceChatModel
+
+class Person(BaseModel):
+    name: str = Field(..., description="Full name")
+    age: int = Field(..., description="Age in years")
+
+chat = IOIntelligenceChatModel(model="meta-llama/Llama-3.3-70B-Instruct")
+structured = chat.with_structured_output(Person)          # default: function_calling
+
+person = structured.invoke("Jane Doe is 32 years old.")
+print(person.name, person.age)                            # Jane Doe 32
+```
+
+Choose how structure is enforced via `method`:
+
+- `"function_calling"` (default) — forces a tool call shaped like the schema.
+- `"json_schema"` — uses the API's `response_format` json_schema (strict).
+- `"json_mode"` — requests a generic JSON object (describe the schema in your prompt).
+
+Pass `include_raw=True` to get `{"raw", "parsed", "parsing_error"}` instead of
+raising on a parse failure.
 
 ## 🔗 Advanced LangChain Integration
 

--- a/examples/tool_calling_usage.py
+++ b/examples/tool_calling_usage.py
@@ -1,0 +1,77 @@
+"""Tool calling and structured output example for langchain-iointelligence.
+
+Run with IO_API_KEY / IO_API_URL set in your environment or .env file.
+"""
+
+from dotenv import load_dotenv
+from langchain_core.messages import HumanMessage, ToolMessage
+from langchain_core.tools import tool
+from pydantic import BaseModel, Field
+
+from langchain_iointelligence import IOIntelligenceChatModel
+
+load_dotenv()
+
+MODEL = "meta-llama/Llama-3.3-70B-Instruct"
+
+
+@tool
+def get_weather(location: str) -> str:
+    """Get the current weather for a location."""
+    # Pretend backend lookup.
+    return f"It's 22C and sunny in {location}."
+
+
+def tool_calling_demo():
+    print("🛠️  Tool calling")
+    print("=" * 50)
+    chat = IOIntelligenceChatModel(model=MODEL)
+    llm_with_tools = chat.bind_tools([get_weather])
+
+    messages = [HumanMessage(content="What's the weather in Tokyo?")]
+    ai_msg = llm_with_tools.invoke(messages)
+    print("tool_calls:", ai_msg.tool_calls)
+
+    # Execute the requested tool(s) and feed results back for a final answer.
+    messages.append(ai_msg)
+    for call in ai_msg.tool_calls:
+        result = get_weather.invoke(call["args"])
+        messages.append(ToolMessage(content=result, tool_call_id=call["id"]))
+
+    final = llm_with_tools.invoke(messages)
+    print("final answer:", final.content)
+
+
+class Person(BaseModel):
+    """A person extracted from text."""
+
+    name: str = Field(..., description="Full name")
+    age: int = Field(..., description="Age in years")
+
+
+def structured_output_demo():
+    print("\n🧱 Structured output")
+    print("=" * 50)
+    chat = IOIntelligenceChatModel(model=MODEL)
+    structured = chat.with_structured_output(Person)  # method="function_calling"
+
+    person = structured.invoke("Jane Doe is 32 years old and lives in Osaka.")
+    print("parsed:", person)
+
+    # Alternative methods:
+    #   chat.with_structured_output(Person, method="json_schema")
+    #   chat.with_structured_output(Person, method="json_mode")
+    #   chat.with_structured_output(Person, include_raw=True)
+
+
+def main():
+    try:
+        tool_calling_demo()
+        structured_output_demo()
+    except Exception as e:  # noqa: BLE001
+        print(f"❌ Error: {e}")
+        print("Make sure IO_API_KEY and IO_API_URL are set in your .env file")
+
+
+if __name__ == "__main__":
+    main()

--- a/langchain_iointelligence/__init__.py
+++ b/langchain_iointelligence/__init__.py
@@ -14,7 +14,7 @@ from .vision import (DEFAULT_VISION_MODEL, MAX_IMAGES_PER_REQUEST,
                      VISION_MODELS, encode_image_to_data_url,
                      image_content_block, vision_message)
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 __all__ = [
     "IOIntelligenceLLM",
     "IOIntelligenceChatModel",

--- a/langchain_iointelligence/chat.py
+++ b/langchain_iointelligence/chat.py
@@ -1,16 +1,30 @@
 """Enhanced IOIntelligenceChatModel implementation for LangChain."""
 
+import json
 import os
-from typing import Any, Dict, Iterator, List, Optional
+from operator import itemgetter
+from typing import (Any, Callable, Dict, Iterator, List, Literal, Optional,
+                    Sequence, Type, Union)
 
 from dotenv import load_dotenv
 from langchain_core.callbacks.manager import CallbackManagerForLLMRun
+from langchain_core.language_models import LanguageModelInput
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import (AIMessage, BaseMessage, HumanMessage,
-                                     SystemMessage)
+                                     SystemMessage, ToolMessage)
 from langchain_core.messages.ai import UsageMetadata
+from langchain_core.output_parsers import (JsonOutputParser,
+                                           PydanticOutputParser)
+from langchain_core.output_parsers.openai_tools import (
+    JsonOutputKeyToolsParser, PydanticToolsParser, make_invalid_tool_call,
+    parse_tool_call)
 from langchain_core.outputs import (ChatGeneration, ChatGenerationChunk,
                                     ChatResult)
+from langchain_core.runnables import Runnable, RunnableMap, RunnablePassthrough
+from langchain_core.tools import BaseTool
+from langchain_core.utils.function_calling import convert_to_openai_tool
+from langchain_core.utils.pydantic import is_basemodel_subclass
+from pydantic import BaseModel
 
 try:
     from .exceptions import (IOIntelligenceError,
@@ -32,6 +46,86 @@ except ImportError:
 
 # Load environment variables from .env file
 load_dotenv()
+
+
+def _lc_tool_call_to_openai(tool_call: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert a LangChain ToolCall dict to the OpenAI tool_call wire format."""
+    return {
+        "id": tool_call.get("id"),
+        "type": "function",
+        "function": {
+            "name": tool_call["name"],
+            "arguments": json.dumps(tool_call.get("args", {})),
+        },
+    }
+
+
+def _convert_message_to_dict(message: BaseMessage) -> Dict[str, Any]:
+    """Convert a single LangChain message to the OpenAI chat message format."""
+    if isinstance(message, HumanMessage):
+        return {"role": "user", "content": message.content}
+    if isinstance(message, SystemMessage):
+        return {"role": "system", "content": message.content}
+    if isinstance(message, ToolMessage):
+        return {
+            "role": "tool",
+            "content": message.content,
+            "tool_call_id": message.tool_call_id,
+        }
+    if isinstance(message, AIMessage):
+        result: Dict[str, Any] = {
+            "role": "assistant",
+            "content": message.content or "",
+        }
+        # Prefer the structured tool_calls; fall back to any raw payload.
+        if message.tool_calls:
+            result["tool_calls"] = [
+                _lc_tool_call_to_openai(tc) for tc in message.tool_calls
+            ]
+            # OpenAI-compatible APIs expect content to be null when only
+            # tool calls are present.
+            if not message.content:
+                result["content"] = None
+        elif message.additional_kwargs.get("tool_calls"):
+            result["tool_calls"] = message.additional_kwargs["tool_calls"]
+        return result
+    # Generic / unknown message types default to a user turn.
+    return {"role": "user", "content": message.content}
+
+
+def _parse_response_tool_calls(message: Dict[str, Any]) -> tuple:
+    """Parse raw OpenAI tool_calls into LangChain (valid, invalid) lists."""
+    tool_calls: List[Dict[str, Any]] = []
+    invalid_tool_calls: List[Dict[str, Any]] = []
+    for raw_tool_call in message.get("tool_calls") or []:
+        try:
+            parsed = parse_tool_call(raw_tool_call, return_id=True)
+            if parsed is not None:
+                tool_calls.append(parsed)
+        except Exception as exc:  # noqa: BLE001 - surfaced as invalid tool call
+            invalid_tool_calls.append(
+                make_invalid_tool_call(raw_tool_call, str(exc))
+            )
+    return tool_calls, invalid_tool_calls
+
+
+def _format_tool_choice(
+    tool_choice: Union[str, bool, dict], tool_names: List[str]
+) -> Union[str, dict]:
+    """Normalise a user-supplied tool_choice into the OpenAI wire format."""
+    if isinstance(tool_choice, bool):
+        return "required" if tool_choice else "none"
+    if isinstance(tool_choice, dict):
+        return tool_choice
+    if tool_choice in ("auto", "none", "required"):
+        return tool_choice
+    if tool_choice == "any":
+        return "required"
+    # Treat any other string as the name of a specific tool to force.
+    if tool_choice in tool_names:
+        return {"type": "function", "function": {"name": tool_choice}}
+    # Unknown string - pass through and let the API validate it.
+    return tool_choice
 
 
 class IOIntelligenceChatModel(BaseChatModel):
@@ -158,22 +252,16 @@ class IOIntelligenceChatModel(BaseChatModel):
             )
         return self._utils
 
-    def _convert_messages_to_api_format(self, messages: List[BaseMessage]) -> List[Dict[str, str]]:
-        """Convert LangChain messages to API format."""
-        api_messages = []
+    def _convert_messages_to_api_format(
+        self, messages: List[BaseMessage]
+    ) -> List[Dict[str, Any]]:
+        """Convert LangChain messages to API format.
 
-        for message in messages:
-            if isinstance(message, HumanMessage):
-                api_messages.append({"role": "user", "content": message.content})
-            elif isinstance(message, AIMessage):
-                api_messages.append({"role": "assistant", "content": message.content})
-            elif isinstance(message, SystemMessage):
-                api_messages.append({"role": "system", "content": message.content})
-            else:
-                # Generic message - default to user
-                api_messages.append({"role": "user", "content": message.content})
-
-        return api_messages
+        Handles human/system/AI/tool roles, including assistant tool calls and
+        tool results, so multi-turn tool-calling conversations round-trip
+        correctly.
+        """
+        return [_convert_message_to_dict(message) for message in messages]
 
     def _generate(
         self,
@@ -219,9 +307,16 @@ class IOIntelligenceChatModel(BaseChatModel):
 
             choice = response_data["choices"][0]
 
-            # Chat format: choices[0].message.content
-            if "message" in choice and "content" in choice["message"]:
-                content = choice["message"]["content"]
+            tool_calls: List[Dict[str, Any]] = []
+            invalid_tool_calls: List[Dict[str, Any]] = []
+
+            # Chat format: choices[0].message (content and/or tool_calls)
+            if "message" in choice:
+                response_message = choice["message"]
+                content = response_message.get("content") or ""
+                tool_calls, invalid_tool_calls = _parse_response_tool_calls(
+                    response_message
+                )
             # Completion format: choices[0].text
             elif "text" in choice:
                 content = choice["text"]
@@ -237,17 +332,19 @@ class IOIntelligenceChatModel(BaseChatModel):
 
             # Create AIMessage with the response
             raw_usage = response_data.get("usage", {})
-            
+
             # Create LangChain standard UsageMetadata
             usage_metadata = UsageMetadata(
                 input_tokens=raw_usage.get("prompt_tokens", 0),
                 output_tokens=raw_usage.get("completion_tokens", 0),
                 total_tokens=raw_usage.get("total_tokens", 0),
             )
-            
+
             # Create AIMessage with proper usage_metadata and response_metadata
             message = AIMessage(
                 content=content,
+                tool_calls=tool_calls,
+                invalid_tool_calls=invalid_tool_calls,
                 usage_metadata=usage_metadata,
                 response_metadata={
                     "token_usage": raw_usage,
@@ -340,6 +437,117 @@ class IOIntelligenceChatModel(BaseChatModel):
                 generation_info=result.generations[0].generation_info,
             )
             yield chunk
+
+    def bind_tools(
+        self,
+        tools: Sequence[Union[Dict[str, Any], type, Callable, BaseTool]],
+        *,
+        tool_choice: Optional[Union[str, bool, dict]] = None,
+        **kwargs: Any,
+    ) -> Runnable[LanguageModelInput, BaseMessage]:
+        """Bind tool-like objects to this model for tool/function calling.
+
+        Args:
+            tools: Tool definitions - any object understood by
+                ``convert_to_openai_tool`` (Pydantic models, ``@tool`` functions,
+                ``BaseTool`` instances, plain functions, or OpenAI tool dicts).
+            tool_choice: Controls which tool is invoked. One of ``"auto"``,
+                ``"none"``, ``"required"``/``"any"``/``True``, a specific tool
+                name, or an explicit OpenAI ``tool_choice`` dict.
+
+        Returns:
+            A runnable that always sends the bound tools to the API.
+        """
+        formatted_tools = [convert_to_openai_tool(tool) for tool in tools]
+        if tool_choice is not None:
+            tool_names = [t["function"]["name"] for t in formatted_tools]
+            kwargs["tool_choice"] = _format_tool_choice(tool_choice, tool_names)
+        return super().bind(tools=formatted_tools, **kwargs)
+
+    def with_structured_output(
+        self,
+        schema: Union[Dict, type],
+        *,
+        method: Literal[
+            "function_calling", "json_schema", "json_mode"
+        ] = "function_calling",
+        include_raw: bool = False,
+        **kwargs: Any,
+    ) -> Runnable[LanguageModelInput, Union[Dict, BaseModel]]:
+        """Return a runnable that produces structured output matching ``schema``.
+
+        Args:
+            schema: A Pydantic ``BaseModel`` subclass, a TypedDict, or an OpenAI
+                function/JSON-schema dict describing the desired output.
+            method: How to enforce structure:
+                ``"function_calling"`` (default) forces a tool call;
+                ``"json_schema"`` uses the API's ``response_format`` json_schema;
+                ``"json_mode"`` requests a generic JSON object (the schema must
+                be described in the prompt).
+            include_raw: When True, return ``{"raw", "parsed", "parsing_error"}``
+                instead of just the parsed value.
+
+        Returns:
+            A runnable emitting the parsed object (or the raw/parsed/error dict).
+        """
+        if schema is None:
+            raise ValueError("schema must be provided to with_structured_output")
+
+        is_pydantic_schema = isinstance(schema, type) and is_basemodel_subclass(
+            schema
+        )
+
+        if method == "function_calling":
+            tool_name = convert_to_openai_tool(schema)["function"]["name"]
+            llm = self.bind_tools([schema], tool_choice=tool_name)
+            if is_pydantic_schema:
+                output_parser: Runnable = PydanticToolsParser(
+                    tools=[schema], first_tool_only=True
+                )
+            else:
+                output_parser = JsonOutputKeyToolsParser(
+                    key_name=tool_name, first_tool_only=True
+                )
+        elif method == "json_schema":
+            function = convert_to_openai_tool(schema)["function"]
+            response_format = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": function["name"],
+                    "schema": function["parameters"],
+                    "strict": True,
+                },
+            }
+            llm = self.bind(response_format=response_format)
+            output_parser = (
+                PydanticOutputParser(pydantic_object=schema)
+                if is_pydantic_schema
+                else JsonOutputParser()
+            )
+        elif method == "json_mode":
+            llm = self.bind(response_format={"type": "json_object"})
+            output_parser = (
+                PydanticOutputParser(pydantic_object=schema)
+                if is_pydantic_schema
+                else JsonOutputParser()
+            )
+        else:
+            raise ValueError(
+                f"Unsupported method '{method}'. Expected one of "
+                "'function_calling', 'json_schema', 'json_mode'."
+            )
+
+        if include_raw:
+            parser_assign = RunnablePassthrough.assign(
+                parsed=itemgetter("raw") | output_parser,
+                parsing_error=lambda _: None,
+            )
+            parser_none = RunnablePassthrough.assign(parsed=lambda _: None)
+            parser_with_fallback = parser_assign.with_fallbacks(
+                [parser_none], exception_key="parsing_error"
+            )
+            return RunnableMap(raw=llm) | parser_with_fallback
+        return llm | output_parser
 
     @property
     def _identifying_params(self) -> Dict[str, Any]:

--- a/langchain_iointelligence/streaming.py
+++ b/langchain_iointelligence/streaming.py
@@ -106,11 +106,30 @@ class IOIntelligenceStreamer:
             delta = choice.get("delta", {})
 
             # Extract content from delta
-            content = delta.get("content", "")
+            content = delta.get("content") or ""
             finish_reason = choice.get("finish_reason")
 
-            # Create message chunk
-            message_chunk = AIMessageChunk(content=content)
+            # Extract incremental tool-call deltas, if any
+            tool_call_chunks = []
+            for raw_tool_call in delta.get("tool_calls") or []:
+                function = raw_tool_call.get("function", {})
+                tool_call_chunks.append(
+                    {
+                        "name": function.get("name"),
+                        "args": function.get("arguments"),
+                        "id": raw_tool_call.get("id"),
+                        "index": raw_tool_call.get("index"),
+                        "type": "tool_call_chunk",
+                    }
+                )
+
+            # Create message chunk (with tool-call deltas when present)
+            if tool_call_chunks:
+                message_chunk = AIMessageChunk(
+                    content=content, tool_call_chunks=tool_call_chunks
+                )
+            else:
+                message_chunk = AIMessageChunk(content=content)
 
             # Create generation chunk
             generation_chunk = ChatGenerationChunk(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-iointelligence"
-version = "0.3.0"
+version = "0.4.0"
 description = "LangChain integration for io Intelligence LLM API with OpenAI compatibility"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -36,7 +36,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "langchain-core>=0.1.0",
+    "langchain-core>=0.2.0",
     "requests>=2.25.0",
     "python-dotenv>=0.19.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Runtime dependencies (kept in sync with pyproject.toml [project].dependencies).
 # For development tooling install the package with its extras instead:
 #   pip install -e ".[dev]"
-langchain-core>=0.1.0
+langchain-core>=0.2.0
 requests>=2.25.0
 python-dotenv>=0.19.0

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,291 @@
+"""Tests for tool/function calling and structured output."""
+
+from unittest.mock import patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from pydantic import BaseModel, Field
+
+from langchain_iointelligence.chat import (IOIntelligenceChatModel,
+                                           _convert_message_to_dict,
+                                           _format_tool_choice,
+                                           _lc_tool_call_to_openai,
+                                           _parse_response_tool_calls)
+
+
+def _model():
+    return IOIntelligenceChatModel(
+        api_key="k", api_url="https://test.api.com/v1/chat/completions"
+    )
+
+
+class GetWeather(BaseModel):
+    """Get the current weather in a location."""
+
+    location: str = Field(..., description="City name")
+
+
+def _tool_call_response(name="GetWeather", args='{"location": "Tokyo"}'):
+    return {
+        "id": "resp-1",
+        "model": "m",
+        "choices": [
+            {
+                "finish_reason": "tool_calls",
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_abc",
+                            "type": "function",
+                            "function": {"name": name, "arguments": args},
+                        }
+                    ],
+                },
+            }
+        ],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12},
+    }
+
+
+class TestMessageConversion:
+    def test_tool_message_role(self):
+        d = _convert_message_to_dict(
+            ToolMessage(content="22C", tool_call_id="call_abc")
+        )
+        assert d == {"role": "tool", "content": "22C", "tool_call_id": "call_abc"}
+
+    def test_ai_message_with_tool_calls(self):
+        msg = AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "GetWeather",
+                    "args": {"location": "Tokyo"},
+                    "id": "call_abc",
+                    "type": "tool_call",
+                }
+            ],
+        )
+        d = _convert_message_to_dict(msg)
+        assert d["role"] == "assistant"
+        assert d["content"] is None
+        assert d["tool_calls"][0]["function"]["name"] == "GetWeather"
+        # arguments must be a JSON string
+        assert d["tool_calls"][0]["function"]["arguments"] == '{"location": "Tokyo"}'
+
+    def test_lc_tool_call_to_openai(self):
+        out = _lc_tool_call_to_openai(
+            {"name": "f", "args": {"x": 1}, "id": "id1"}
+        )
+        assert out["type"] == "function"
+        assert out["id"] == "id1"
+        assert out["function"]["arguments"] == '{"x": 1}'
+
+
+class TestToolChoiceFormatting:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (True, "required"),
+            (False, "none"),
+            ("auto", "auto"),
+            ("none", "none"),
+            ("required", "required"),
+            ("any", "required"),
+        ],
+    )
+    def test_keywords(self, value, expected):
+        assert _format_tool_choice(value, ["GetWeather"]) == expected
+
+    def test_named_tool(self):
+        assert _format_tool_choice("GetWeather", ["GetWeather"]) == {
+            "type": "function",
+            "function": {"name": "GetWeather"},
+        }
+
+    def test_passthrough_dict(self):
+        d = {"type": "function", "function": {"name": "x"}}
+        assert _format_tool_choice(d, []) is d
+
+
+class TestParseResponseToolCalls:
+    def test_valid(self):
+        valid, invalid = _parse_response_tool_calls(
+            {
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "GetWeather", "arguments": '{"location": "Tokyo"}'},
+                    }
+                ]
+            }
+        )
+        assert not invalid
+        assert valid[0]["name"] == "GetWeather"
+        assert valid[0]["args"] == {"location": "Tokyo"}
+        assert valid[0]["id"] == "c1"
+
+    def test_invalid_arguments(self):
+        valid, invalid = _parse_response_tool_calls(
+            {
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "GetWeather", "arguments": "{not json"},
+                    }
+                ]
+            }
+        )
+        assert not valid
+        assert invalid and invalid[0]["type"] == "invalid_tool_call"
+
+
+class TestBindTools:
+    def test_bind_tools_sends_schema_and_choice(self):
+        chat = _model()
+        bound = chat.bind_tools([GetWeather], tool_choice="GetWeather")
+        kwargs = bound.kwargs
+        assert kwargs["tools"][0]["function"]["name"] == "GetWeather"
+        assert kwargs["tool_choice"] == {
+            "type": "function",
+            "function": {"name": "GetWeather"},
+        }
+
+    def test_invoke_parses_tool_calls(self):
+        chat = _model()
+        with patch.object(
+            IOIntelligenceChatModel, "http_client", None
+        ), patch.object(
+            chat, "_fallback_request", return_value=_tool_call_response()
+        ):
+            result = chat.bind_tools([GetWeather]).invoke(
+                [HumanMessage(content="weather in Tokyo?")]
+            )
+        assert isinstance(result, AIMessage)
+        assert result.tool_calls
+        assert result.tool_calls[0]["name"] == "GetWeather"
+        assert result.tool_calls[0]["args"] == {"location": "Tokyo"}
+        assert result.usage_metadata["total_tokens"] == 12
+
+
+class TestStructuredOutput:
+    def test_function_calling_pydantic(self):
+        chat = _model()
+        runnable = chat.with_structured_output(GetWeather)
+        with patch.object(
+            IOIntelligenceChatModel, "http_client", None
+        ), patch.object(
+            chat, "_fallback_request", return_value=_tool_call_response()
+        ):
+            out = runnable.invoke([HumanMessage(content="weather in Tokyo?")])
+        assert isinstance(out, GetWeather)
+        assert out.location == "Tokyo"
+
+    def test_function_calling_sets_response_tool_choice(self):
+        chat = _model()
+        # The bound runnable should force the tool.
+        runnable = chat.with_structured_output(GetWeather)
+        # First step of the chain is the bound LLM.
+        bound = runnable.steps[0] if hasattr(runnable, "steps") else runnable.first
+        assert bound.kwargs["tool_choice"]["function"]["name"] == "GetWeather"
+
+    def test_json_schema_sets_response_format(self):
+        chat = _model()
+        runnable = chat.with_structured_output(GetWeather, method="json_schema")
+        bound = runnable.first
+        rf = bound.kwargs["response_format"]
+        assert rf["type"] == "json_schema"
+        assert rf["json_schema"]["name"] == "GetWeather"
+        assert "location" in rf["json_schema"]["schema"]["properties"]
+
+    def test_json_mode_sets_response_format(self):
+        chat = _model()
+        runnable = chat.with_structured_output(GetWeather, method="json_mode")
+        bound = runnable.first
+        assert bound.kwargs["response_format"] == {"type": "json_object"}
+
+    def test_invalid_method(self):
+        chat = _model()
+        with pytest.raises(ValueError, match="Unsupported method"):
+            chat.with_structured_output(GetWeather, method="nope")
+
+    def test_json_schema_parses_content(self):
+        chat = _model()
+        json_resp = {
+            "id": "1",
+            "model": "m",
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": '{"location": "Tokyo"}'},
+                }
+            ],
+            "usage": {},
+        }
+        runnable = chat.with_structured_output(GetWeather, method="json_schema")
+        with patch.object(
+            IOIntelligenceChatModel, "http_client", None
+        ), patch.object(chat, "_fallback_request", return_value=json_resp):
+            out = runnable.invoke([HumanMessage(content="x")])
+        assert isinstance(out, GetWeather)
+        assert out.location == "Tokyo"
+
+    def test_include_raw(self):
+        chat = _model()
+        runnable = chat.with_structured_output(GetWeather, include_raw=True)
+        with patch.object(
+            IOIntelligenceChatModel, "http_client", None
+        ), patch.object(chat, "_fallback_request", return_value=_tool_call_response()):
+            out = runnable.invoke([HumanMessage(content="x")])
+        assert set(out.keys()) == {"raw", "parsed", "parsing_error"}
+        assert isinstance(out["parsed"], GetWeather)
+        assert out["parsing_error"] is None
+
+
+class TestMultiTurnRoundTrip:
+    def test_tool_conversation_roundtrips(self):
+        chat = _model()
+        messages = [
+            HumanMessage(content="weather?"),
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "GetWeather",
+                        "args": {"location": "Tokyo"},
+                        "id": "c1",
+                        "type": "tool_call",
+                    }
+                ],
+            ),
+            ToolMessage(content="22C", tool_call_id="c1"),
+        ]
+        api = chat._convert_messages_to_api_format(messages)
+        assert [m["role"] for m in api] == ["user", "assistant", "tool"]
+        assert api[1]["tool_calls"][0]["function"]["name"] == "GetWeather"
+        assert api[2]["tool_call_id"] == "c1"
+
+
+class TestStreamingToolCalls:
+    def test_tool_call_chunks_accumulate(self):
+        from langchain_iointelligence.streaming import IOIntelligenceStreamer
+
+        streamer = IOIntelligenceStreamer("k", "https://x")
+        deltas = [
+            {"choices": [{"delta": {"tool_calls": [
+                {"index": 0, "id": "c1", "function": {"name": "GetWeather", "arguments": ""}}]}}]},
+            {"choices": [{"delta": {"tool_calls": [
+                {"index": 0, "function": {"arguments": '{"location":'}}]}}]},
+            {"choices": [{"delta": {"tool_calls": [
+                {"index": 0, "function": {"arguments": '"Tokyo"}'}}]}}]},
+        ]
+        chunks = [streamer._create_chat_chunk(d) for d in deltas]
+        merged = chunks[0]
+        for chunk in chunks[1:]:
+            merged = merged + chunk
+        assert merged.message.tool_calls[0]["name"] == "GetWeather"
+        assert merged.message.tool_calls[0]["args"] == {"location": "Tokyo"}


### PR DESCRIPTION
## Summary

Adds the two biggest gaps for agent/extraction use, both backed by io Intelligence's OpenAI-compatible API (`tools`/`tool_choice` and `response_format` json_object/json_schema are documented as supported).

### 🛠️ Tool / function calling
- **`bind_tools(tools, *, tool_choice=...)`** — formats tools via `convert_to_openai_tool` (Pydantic models, `@tool` fns, `BaseTool`, plain fns, raw dicts). `tool_choice` accepts `auto`/`none`/`required`/`any`, a bool, a specific tool name, or an explicit OpenAI dict.
- Responses parse `message.tool_calls` into standard **`AIMessage.tool_calls`** / `invalid_tool_calls` (content may be null).
- **Message conversion** now handles `ToolMessage` (`role=tool`, `tool_call_id`) and serialises `AIMessage.tool_calls` back to OpenAI format → **multi-turn tool conversations round-trip**.
- **Streaming** surfaces incremental `tool_call_chunks`, so tool calls aren't dropped when streaming.

### 🧱 Structured output
- **`with_structured_output(schema, *, method=, include_raw=)`** with three methods:
  - `function_calling` (default) — forces a tool shaped like the schema,
  - `json_schema` — uses `response_format` json_schema (strict),
  - `json_mode` — generic JSON object.
- Supports Pydantic models and JSON-schema dicts; standard `include_raw` → `{raw, parsed, parsing_error}`.

### Housekeeping
- Version **0.3.0 → 0.4.0**; `langchain-core` floor raised to **>=0.2.0** (needed for `tool_calls` / `with_structured_output`).
- README feature matrix + new docs; `examples/tool_calling_usage.py`.

## Testing
- **80 tests pass** (24 new in `tests/test_tools.py`), covering message conversion, tool_choice formatting, tool-call parsing (valid + invalid), `bind_tools`, all three structured-output methods, `include_raw`, multi-turn round-trip, and streaming tool-call accumulation.
- `python -m build` + `twine check`: clean. Fresh-venv install of the 0.4.0 wheel exposes `bind_tools` / `with_structured_output`.
- CI matrix (3.9–3.13) runs on this PR.

## Notes
- No breaking changes to existing text/vision APIs.
- `IOIntelligenceLLM` (string interface) is unchanged; tool calling lives on `IOIntelligenceChatModel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)