### PR TITLE
Native async (httpx) + streaming usage metadata (0.5.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@
 | ✅ **Vision/Multimodal** | **Supported** | Image input via `vision_message()` on vision models (0.3.0+) |
 | ✅ **Function/Tool Calling** | **Supported** | `bind_tools()` with tool-call parsing + streaming (0.4.0+) |
 | ✅ **Structured Output** | **Supported** | `with_structured_output()` — function calling / json_schema / json_mode (0.4.0+) |
-| ⚠️ **Streaming** | **Basic Support** | SSE token + tool-call chunks; usage-at-end *coming soon* |
+| ✅ **Async** | **Supported** | Native `ainvoke`/`astream`/`abatch` over httpx (0.5.0+) |
+| ✅ **Streaming** | **Supported** | SSE token + tool-call chunks; usage metadata on the final chunk (0.5.0+) |
 | ❌ **Embeddings** | **Not Supported** | Use dedicated embedding providers |
 
 > **Note**: Non-core message roles default to `user`. Usage metadata always includes all required fields (`input_tokens`, `output_tokens`, `total_tokens`) with defaults of 0 when data unavailable.
@@ -216,6 +217,38 @@ Choose how structure is enforced via `method`:
 
 Pass `include_raw=True` to get `{"raw", "parsed", "parsing_error"}` instead of
 raising on a parse failure.
+
+### **Async** ⚡
+
+All async entry points are implemented natively on top of `httpx`
+(`ainvoke`, `astream`, `abatch`, and the `_agenerate`/`_astream` hooks), so the
+model is a first-class citizen in LangServe / LangGraph and concurrent
+pipelines — no thread-pool wrapping.
+
+```python
+import asyncio
+from langchain_iointelligence import IOIntelligenceChatModel
+
+chat = IOIntelligenceChatModel(model="meta-llama/Llama-3.3-70B-Instruct")
+
+async def main():
+    # Single async call
+    resp = await chat.ainvoke("Give me a haiku about the sea.")
+    print(resp.content)
+
+    # Async streaming
+    async for chunk in chat.astream("Count to five."):
+        print(chunk.content, end="", flush=True)
+
+    # Concurrent calls
+    results = await chat.abatch(["Hi", "Hello", "Hey"])
+
+asyncio.run(main())
+```
+
+Streaming responses now also carry token usage: the final chunk includes
+`usage_metadata` (requested via `stream_options.include_usage`), so you can
+account for tokens even when streaming.
 
 ## 🔗 Advanced LangChain Integration
 

--- a/examples/async_usage.py
+++ b/examples/async_usage.py
@@ -1,0 +1,50 @@
+"""Async usage example for langchain-iointelligence.
+
+Native async (ainvoke / astream / abatch) on top of httpx.
+Run with IO_API_KEY / IO_API_URL set in your environment or .env file.
+"""
+
+import asyncio
+
+from dotenv import load_dotenv
+
+from langchain_iointelligence import IOIntelligenceChatModel
+
+load_dotenv()
+
+MODEL = "meta-llama/Llama-3.3-70B-Instruct"
+
+
+async def main():
+    chat = IOIntelligenceChatModel(model=MODEL)
+
+    print("⚡ ainvoke")
+    print("=" * 50)
+    resp = await chat.ainvoke("Give me a one-line fun fact about octopuses.")
+    print(resp.content)
+    if resp.usage_metadata:
+        print("tokens:", resp.usage_metadata)
+
+    print("\n⚡ astream (with usage on the final chunk)")
+    print("=" * 50)
+    usage = None
+    async for chunk in chat.astream("Count from one to five."):
+        print(chunk.content, end="", flush=True)
+        if chunk.usage_metadata:
+            usage = chunk.usage_metadata
+    print()
+    print("stream usage:", usage)
+
+    print("\n⚡ abatch (concurrent)")
+    print("=" * 50)
+    results = await chat.abatch(["Say hi", "Say hello", "Say hey"])
+    for r in results:
+        print("-", r.content)
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except Exception as e:  # noqa: BLE001
+        print(f"❌ Error: {e}")
+        print("Make sure IO_API_KEY and IO_API_URL are set in your .env file")

--- a/langchain_iointelligence/__init__.py
+++ b/langchain_iointelligence/__init__.py
@@ -14,7 +14,7 @@ from .vision import (DEFAULT_VISION_MODEL, MAX_IMAGES_PER_REQUEST,
                      VISION_MODELS, encode_image_to_data_url,
                      image_content_block, vision_message)
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 __all__ = [
     "IOIntelligenceLLM",
     "IOIntelligenceChatModel",

--- a/langchain_iointelligence/async_http_client.py
+++ b/langchain_iointelligence/async_http_client.py
@@ -1,0 +1,117 @@
+"""Async HTTP client (httpx) with retry logic for io Intelligence API."""
+
+import asyncio
+import json
+from typing import Any, AsyncIterator, Dict
+
+import httpx
+
+from .exceptions import (IOIntelligenceConnectionError, IOIntelligenceError,
+                         IOIntelligenceRateLimitError,
+                         IOIntelligenceServerError, IOIntelligenceTimeoutError,
+                         classify_api_error)
+
+
+class IOIntelligenceAsyncHTTPClient:
+    """Async HTTP client mirroring the sync client's retry/error behaviour."""
+
+    def __init__(
+        self,
+        api_key: str,
+        api_url: str,
+        timeout: int = 30,
+        max_retries: int = 3,
+        retry_delay: float = 1.0,
+    ):
+        self.api_key = api_key
+        self.api_url = api_url
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self.retry_delay = retry_delay
+        self._headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+    async def apost_with_retry(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Async POST with automatic retry on rate-limit/server/network errors."""
+        last_exception = None
+
+        for attempt in range(self.max_retries + 1):
+            try:
+                async with httpx.AsyncClient(timeout=self.timeout) as client:
+                    response = await client.post(
+                        self.api_url, headers=self._headers, json=data
+                    )
+
+                if response.status_code >= 400:
+                    error = classify_api_error(response.status_code, response.text)
+                    if isinstance(
+                        error,
+                        (IOIntelligenceRateLimitError, IOIntelligenceServerError),
+                    ) and attempt < self.max_retries:
+                        delay = self.retry_delay * (2**attempt)
+                        if isinstance(error, IOIntelligenceRateLimitError):
+                            delay = max(delay, 60)
+                        await asyncio.sleep(delay)
+                        continue
+                    raise error
+
+                return response.json()
+
+            except IOIntelligenceError:
+                # Classified API errors (auth/client/non-retryable server) must
+                # propagate as-is - they subclass ValueError, so they would
+                # otherwise be swallowed by the JSON-decode handler below.
+                raise
+            except httpx.TimeoutException:
+                last_exception = IOIntelligenceTimeoutError(
+                    f"Request timeout after {self.timeout} seconds"
+                )
+                if attempt < self.max_retries:
+                    await asyncio.sleep(self.retry_delay * (2**attempt))
+                    continue
+            except httpx.HTTPError as exc:
+                last_exception = IOIntelligenceConnectionError(
+                    f"Connection error: {str(exc)}"
+                )
+                if attempt < self.max_retries:
+                    await asyncio.sleep(self.retry_delay * (2**attempt))
+                    continue
+            except ValueError as exc:  # JSON decode error - don't retry
+                last_exception = IOIntelligenceError(
+                    f"Invalid JSON response: {str(exc)}"
+                )
+                break
+
+        raise last_exception or IOIntelligenceError("All retry attempts failed")
+
+    async def astream(self, data: Dict[str, Any]) -> AsyncIterator[Dict[str, Any]]:
+        """Async stream of parsed SSE chunk dicts from the chat endpoint."""
+        headers = {**self._headers, "Accept": "text/event-stream"}
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                async with client.stream(
+                    "POST", self.api_url, headers=headers, json=data
+                ) as response:
+                    if response.status_code >= 400:
+                        body = await response.aread()
+                        text = body.decode() if isinstance(body, bytes) else str(body)
+                        raise classify_api_error(response.status_code, text)
+
+                    async for line in response.aiter_lines():
+                        if not line or not line.startswith("data: "):
+                            continue
+                        payload = line[6:].strip()
+                        if payload == "[DONE]":
+                            break
+                        try:
+                            yield json.loads(payload)
+                        except json.JSONDecodeError:
+                            continue
+        except httpx.TimeoutException:
+            raise IOIntelligenceTimeoutError(
+                f"Request timeout after {self.timeout} seconds"
+            )
+        except httpx.HTTPError as exc:
+            raise IOIntelligenceConnectionError(f"Connection error: {str(exc)}")

--- a/langchain_iointelligence/chat.py
+++ b/langchain_iointelligence/chat.py
@@ -3,11 +3,12 @@
 import json
 import os
 from operator import itemgetter
-from typing import (Any, Callable, Dict, Iterator, List, Literal, Optional,
-                    Sequence, Type, Union)
+from typing import (Any, AsyncIterator, Callable, Dict, Iterator, List,
+                    Literal, Optional, Sequence, Type, Union)
 
 from dotenv import load_dotenv
-from langchain_core.callbacks.manager import CallbackManagerForLLMRun
+from langchain_core.callbacks.manager import (AsyncCallbackManagerForLLMRun,
+                                              CallbackManagerForLLMRun)
 from langchain_core.language_models import LanguageModelInput
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import (AIMessage, BaseMessage, HumanMessage,
@@ -27,15 +28,18 @@ from langchain_core.utils.pydantic import is_basemodel_subclass
 from pydantic import BaseModel
 
 try:
+    from .async_http_client import IOIntelligenceAsyncHTTPClient
     from .exceptions import (IOIntelligenceError,
                              IOIntelligenceInvalidResponseError)
     from .http_client import IOIntelligenceHTTPClient
-    from .streaming import IOIntelligenceStreamer
+    from .streaming import IOIntelligenceStreamer, build_generation_chunk
     from .utils import IOIntelligenceUtils
 except ImportError:
     # Fallback for basic functionality if enhanced modules aren't available
     IOIntelligenceHTTPClient = None
+    IOIntelligenceAsyncHTTPClient = None
     IOIntelligenceStreamer = None
+    build_generation_chunk = None
     IOIntelligenceError = Exception
     IOIntelligenceInvalidResponseError = Exception
     IOIntelligenceUtils = None
@@ -213,6 +217,7 @@ class IOIntelligenceChatModel(BaseChatModel):
 
         # Initialize enhanced features if available
         self._http_client: Optional[Any] = None
+        self._async_http_client: Optional[Any] = None
         self._streamer: Optional[Any] = None
         self._utils: Optional[Any] = None
 
@@ -233,6 +238,22 @@ class IOIntelligenceChatModel(BaseChatModel):
                 retry_delay=self.retry_delay,
             )
         return self._http_client
+
+    @property
+    def async_http_client(self):
+        """Get or create the async HTTP client."""
+        if (
+            IOIntelligenceAsyncHTTPClient is not None
+            and self._async_http_client is None
+        ):
+            self._async_http_client = IOIntelligenceAsyncHTTPClient(
+                api_key=self.io_api_key,
+                api_url=self.io_api_url,
+                timeout=self.timeout,
+                max_retries=self.max_retries,
+                retry_delay=self.retry_delay,
+            )
+        return self._async_http_client
 
     @property
     def streamer(self):
@@ -263,6 +284,111 @@ class IOIntelligenceChatModel(BaseChatModel):
         """
         return [_convert_message_to_dict(message) for message in messages]
 
+    def _build_request_data(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]],
+        *,
+        stream: bool = False,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Assemble the OpenAI-compatible request payload."""
+        data: Dict[str, Any] = {
+            "model": self.model,
+            "messages": self._convert_messages_to_api_format(messages),
+            "temperature": self.temperature,
+            "max_tokens": self.max_tokens,
+        }
+        if stop:
+            data["stop"] = stop
+        if stream:
+            data["stream"] = True
+            # Ask for token usage in the final SSE chunk (caller may override).
+            data.setdefault("stream_options", {"include_usage": True})
+        data.update(kwargs)
+        return data
+
+    def _invalid_response_error(self, message: str) -> Exception:
+        """Build the appropriate invalid-response error instance."""
+        error_class = (
+            IOIntelligenceInvalidResponseError
+            if IOIntelligenceInvalidResponseError != Exception
+            else GenerationError
+        )
+        return error_class(message)
+
+    def _wrap_error(self, error: Exception) -> Exception:
+        """Normalise an arbitrary error into an IOIntelligence error."""
+        if IOIntelligenceError != Exception and isinstance(error, IOIntelligenceError):
+            return error
+        if IOIntelligenceError != Exception:
+            return IOIntelligenceError(f"API request failed: {str(error)}")
+        return GenerationError(f"API request failed: {str(error)}")
+
+    def _create_chat_result(self, response_data: Dict[str, Any]) -> ChatResult:
+        """Parse an API response into a ChatResult (shared by sync and async)."""
+        if "choices" not in response_data or not response_data["choices"]:
+            raise self._invalid_response_error("No choices in API response")
+
+        choice = response_data["choices"][0]
+        tool_calls: List[Dict[str, Any]] = []
+        invalid_tool_calls: List[Dict[str, Any]] = []
+
+        # Chat format: choices[0].message (content and/or tool_calls)
+        if "message" in choice:
+            response_message = choice["message"]
+            content = response_message.get("content") or ""
+            tool_calls, invalid_tool_calls = _parse_response_tool_calls(
+                response_message
+            )
+        # Completion format: choices[0].text
+        elif "text" in choice:
+            content = choice["text"]
+        else:
+            raise self._invalid_response_error(
+                "Unsupported response schema - expected 'message.content' or 'text' in choices"
+            )
+
+        raw_usage = response_data.get("usage") or {}
+        usage_metadata = UsageMetadata(
+            input_tokens=raw_usage.get("prompt_tokens", 0),
+            output_tokens=raw_usage.get("completion_tokens", 0),
+            total_tokens=raw_usage.get("total_tokens", 0),
+        )
+
+        message = AIMessage(
+            content=content,
+            tool_calls=tool_calls,
+            invalid_tool_calls=invalid_tool_calls,
+            usage_metadata=usage_metadata,
+            response_metadata={
+                "token_usage": raw_usage,
+                "model": response_data.get("model", self.model),
+                "finish_reason": choice.get("finish_reason"),
+                "id": response_data.get("id"),
+                "created": response_data.get("created"),
+            },
+        )
+
+        generation = ChatGeneration(
+            message=message,
+            generation_info={
+                "model": self.model,
+                "usage": raw_usage,  # Backward compatibility
+                "finish_reason": choice.get("finish_reason"),
+                "response_id": response_data.get("id"),
+                "created": response_data.get("created"),
+            },
+        )
+
+        return ChatResult(
+            generations=[generation],
+            llm_output={
+                "token_usage": usage_metadata,
+                "model_name": self.model,
+            },
+        )
+
     def _generate(
         self,
         messages: List[BaseMessage],
@@ -271,118 +397,35 @@ class IOIntelligenceChatModel(BaseChatModel):
         **kwargs: Any,
     ) -> ChatResult:
         """Run the LLM on the given messages."""
-        # Convert messages to API format
-        api_messages = self._convert_messages_to_api_format(messages)
-
-        # Prepare request data
-        data = {
-            "model": self.model,
-            "messages": api_messages,
-            "temperature": self.temperature,
-            "max_tokens": self.max_tokens,
-        }
-
-        # Add stop words if provided
-        if stop:
-            data["stop"] = stop
-
-        # Add any additional kwargs
-        data.update(kwargs)
-
+        data = self._build_request_data(messages, stop, **kwargs)
         try:
-            # Use enhanced HTTP client if available, otherwise fallback
             if self.http_client is not None:
                 response_data = self.http_client.post_with_retry(data)
             else:
                 response_data = self._fallback_request(data)
-
-            # Parse response - supports both Chat and Completion formats
-            if "choices" not in response_data or not response_data["choices"]:
-                error_class = (
-                    IOIntelligenceInvalidResponseError
-                    if IOIntelligenceInvalidResponseError != Exception
-                    else GenerationError
-                )
-                raise error_class("No choices in API response")
-
-            choice = response_data["choices"][0]
-
-            tool_calls: List[Dict[str, Any]] = []
-            invalid_tool_calls: List[Dict[str, Any]] = []
-
-            # Chat format: choices[0].message (content and/or tool_calls)
-            if "message" in choice:
-                response_message = choice["message"]
-                content = response_message.get("content") or ""
-                tool_calls, invalid_tool_calls = _parse_response_tool_calls(
-                    response_message
-                )
-            # Completion format: choices[0].text
-            elif "text" in choice:
-                content = choice["text"]
-            else:
-                error_class = (
-                    IOIntelligenceInvalidResponseError
-                    if IOIntelligenceInvalidResponseError != Exception
-                    else GenerationError
-                )
-                raise error_class(
-                    "Unsupported response schema - expected 'message.content' or 'text' in choices"
-                )
-
-            # Create AIMessage with the response
-            raw_usage = response_data.get("usage", {})
-
-            # Create LangChain standard UsageMetadata
-            usage_metadata = UsageMetadata(
-                input_tokens=raw_usage.get("prompt_tokens", 0),
-                output_tokens=raw_usage.get("completion_tokens", 0),
-                total_tokens=raw_usage.get("total_tokens", 0),
-            )
-
-            # Create AIMessage with proper usage_metadata and response_metadata
-            message = AIMessage(
-                content=content,
-                tool_calls=tool_calls,
-                invalid_tool_calls=invalid_tool_calls,
-                usage_metadata=usage_metadata,
-                response_metadata={
-                    "token_usage": raw_usage,
-                    "model": response_data.get("model", self.model),
-                    "finish_reason": choice.get("finish_reason"),
-                    "id": response_data.get("id"),
-                    "created": response_data.get("created"),
-                },
-            )
-
-            generation = ChatGeneration(
-                message=message,
-                generation_info={
-                    "model": self.model,
-                    "usage": raw_usage,  # Backward compatibility
-                    "finish_reason": choice.get("finish_reason"),
-                    "response_id": response_data.get("id"),
-                    "created": response_data.get("created"),
-                },
-            )
-
-            return ChatResult(
-                generations=[generation],
-                llm_output={
-                    "token_usage": usage_metadata,
-                    "model_name": self.model,
-                }
-            )
-
+            return self._create_chat_result(response_data)
         except Exception as e:
-            # Re-raise IOIntelligence-specific errors as-is
-            if IOIntelligenceError != Exception and isinstance(e, IOIntelligenceError):
-                raise
-            # Convert other errors to appropriate types with consistent prefix
-            elif IOIntelligenceError != Exception:
-                raise IOIntelligenceError(f"API request failed: {str(e)}")
-            else:
-                raise GenerationError(f"API request failed: {str(e)}")
+            raise self._wrap_error(e)
+
+    async def _agenerate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        """Asynchronously run the LLM on the given messages (native async)."""
+        if self.async_http_client is None:
+            # No httpx available - fall back to the base thread-pool behaviour.
+            return await super()._agenerate(
+                messages, stop=stop, run_manager=run_manager, **kwargs
+            )
+        data = self._build_request_data(messages, stop, **kwargs)
+        try:
+            response_data = await self.async_http_client.apost_with_retry(data)
+            return self._create_chat_result(response_data)
+        except Exception as e:
+            raise self._wrap_error(e)
 
     def _fallback_request(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """Fallback HTTP request without enhanced features."""
@@ -405,19 +448,7 @@ class IOIntelligenceChatModel(BaseChatModel):
         """Stream the LLM on the given messages."""
         # If streaming is available, use it
         if self.streamer:
-            api_messages = self._convert_messages_to_api_format(messages)
-
-            data = {
-                "model": self.model,
-                "messages": api_messages,
-                "temperature": self.temperature,
-                "max_tokens": self.max_tokens,
-                "stream": True,
-            }
-
-            if stop:
-                data["stop"] = stop
-            data.update(kwargs)
+            data = self._build_request_data(messages, stop, stream=True, **kwargs)
 
             try:
                 for chunk in self.streamer.stream_chat_completion(data):
@@ -437,6 +468,34 @@ class IOIntelligenceChatModel(BaseChatModel):
                 generation_info=result.generations[0].generation_info,
             )
             yield chunk
+
+    async def _astream(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[ChatGenerationChunk]:
+        """Asynchronously stream the LLM on the given messages (native async)."""
+        if self.async_http_client is None or build_generation_chunk is None:
+            # No httpx available - defer to base async-over-sync streaming.
+            async for chunk in super()._astream(
+                messages, stop=stop, run_manager=run_manager, **kwargs
+            ):
+                yield chunk
+            return
+
+        data = self._build_request_data(messages, stop, stream=True, **kwargs)
+        try:
+            async for raw_chunk in self.async_http_client.astream(data):
+                chunk = build_generation_chunk(raw_chunk)
+                if chunk is None:
+                    continue
+                if run_manager:
+                    await run_manager.on_llm_new_token(chunk.message.content or "")
+                yield chunk
+        except Exception as e:
+            raise self._wrap_error(e)
 
     def bind_tools(
         self,

--- a/langchain_iointelligence/http_client.py
+++ b/langchain_iointelligence/http_client.py
@@ -66,6 +66,11 @@ class IOIntelligenceHTTPClient:
 
                 return response.json()
 
+            except IOIntelligenceError:
+                # Classified API errors must propagate as-is; they subclass
+                # ValueError, so they would otherwise be swallowed by the
+                # JSON-decode handler below.
+                raise
             except requests.exceptions.Timeout:
                 last_exception = IOIntelligenceTimeoutError(
                     f"Request timeout after {self.timeout} seconds"

--- a/langchain_iointelligence/streaming.py
+++ b/langchain_iointelligence/streaming.py
@@ -5,9 +5,80 @@ from typing import Any, Dict, Iterator, Optional
 
 import requests
 from langchain_core.messages import AIMessageChunk
+from langchain_core.messages.ai import UsageMetadata
 from langchain_core.outputs import ChatGenerationChunk
 
 from .exceptions import IOIntelligenceError, classify_api_error
+
+
+def build_generation_chunk(
+    chunk_data: Dict[str, Any]
+) -> Optional[ChatGenerationChunk]:
+    """Build a ChatGenerationChunk from a raw SSE chunk dict.
+
+    Shared by the sync streamer and the async stream so both paths produce
+    identical chunks (content deltas, tool-call deltas, and the final
+    usage-only chunk emitted when ``stream_options.include_usage`` is set).
+    """
+    try:
+        choices = chunk_data.get("choices") or []
+        usage = chunk_data.get("usage")
+
+        # Final usage-only chunk (no choices) - surface token usage.
+        if not choices:
+            if usage:
+                usage_metadata = UsageMetadata(
+                    input_tokens=usage.get("prompt_tokens", 0),
+                    output_tokens=usage.get("completion_tokens", 0),
+                    total_tokens=usage.get("total_tokens", 0),
+                )
+                return ChatGenerationChunk(
+                    message=AIMessageChunk(content="", usage_metadata=usage_metadata),
+                    generation_info={
+                        "model": chunk_data.get("model"),
+                        "chunk_id": chunk_data.get("id"),
+                    },
+                )
+            return None
+
+        choice = choices[0]
+        delta = choice.get("delta", {})
+
+        content = delta.get("content") or ""
+        finish_reason = choice.get("finish_reason")
+
+        # Incremental tool-call deltas, if any.
+        tool_call_chunks = []
+        for raw_tool_call in delta.get("tool_calls") or []:
+            function = raw_tool_call.get("function", {})
+            tool_call_chunks.append(
+                {
+                    "name": function.get("name"),
+                    "args": function.get("arguments"),
+                    "id": raw_tool_call.get("id"),
+                    "index": raw_tool_call.get("index"),
+                    "type": "tool_call_chunk",
+                }
+            )
+
+        if tool_call_chunks:
+            message_chunk = AIMessageChunk(
+                content=content, tool_call_chunks=tool_call_chunks
+            )
+        else:
+            message_chunk = AIMessageChunk(content=content)
+
+        return ChatGenerationChunk(
+            message=message_chunk,
+            generation_info={
+                "finish_reason": finish_reason,
+                "model": chunk_data.get("model"),
+                "chunk_id": chunk_data.get("id"),
+            },
+        )
+
+    except (KeyError, TypeError):
+        return None
 
 
 class IOIntelligenceStreamer:
@@ -91,60 +162,10 @@ class IOIntelligenceStreamer:
     def _create_chat_chunk(self, chunk_data: Dict[str, Any]) -> Optional[ChatGenerationChunk]:
         """Create ChatGenerationChunk from API chunk data.
 
-        Args:
-            chunk_data: Raw chunk data from API
-
-        Returns:
-            ChatGenerationChunk or None if invalid
+        Thin wrapper around :func:`build_generation_chunk` (kept for backward
+        compatibility / instance-level access).
         """
-        try:
-            choices = chunk_data.get("choices", [])
-            if not choices:
-                return None
-
-            choice = choices[0]
-            delta = choice.get("delta", {})
-
-            # Extract content from delta
-            content = delta.get("content") or ""
-            finish_reason = choice.get("finish_reason")
-
-            # Extract incremental tool-call deltas, if any
-            tool_call_chunks = []
-            for raw_tool_call in delta.get("tool_calls") or []:
-                function = raw_tool_call.get("function", {})
-                tool_call_chunks.append(
-                    {
-                        "name": function.get("name"),
-                        "args": function.get("arguments"),
-                        "id": raw_tool_call.get("id"),
-                        "index": raw_tool_call.get("index"),
-                        "type": "tool_call_chunk",
-                    }
-                )
-
-            # Create message chunk (with tool-call deltas when present)
-            if tool_call_chunks:
-                message_chunk = AIMessageChunk(
-                    content=content, tool_call_chunks=tool_call_chunks
-                )
-            else:
-                message_chunk = AIMessageChunk(content=content)
-
-            # Create generation chunk
-            generation_chunk = ChatGenerationChunk(
-                message=message_chunk,
-                generation_info={
-                    "finish_reason": finish_reason,
-                    "model": chunk_data.get("model"),
-                    "chunk_id": chunk_data.get("id"),
-                },
-            )
-
-            return generation_chunk
-
-        except (KeyError, TypeError):
-            return None
+        return build_generation_chunk(chunk_data)
 
 
 def stream_text_from_chunks(chunks: Iterator[ChatGenerationChunk]) -> Iterator[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-iointelligence"
-version = "0.4.0"
+version = "0.5.0"
 description = "LangChain integration for io Intelligence LLM API with OpenAI compatibility"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -38,6 +38,7 @@ classifiers = [
 dependencies = [
     "langchain-core>=0.2.0",
     "requests>=2.25.0",
+    "httpx>=0.23.0",
     "python-dotenv>=0.19.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@
 #   pip install -e ".[dev]"
 langchain-core>=0.2.0
 requests>=2.25.0
+httpx>=0.23.0
 python-dotenv>=0.19.0

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,0 +1,200 @@
+"""Tests for native async support and streaming usage metadata."""
+
+import asyncio
+
+from unittest.mock import AsyncMock, patch
+
+from langchain_core.messages import AIMessage, HumanMessage
+
+from langchain_iointelligence.async_http_client import \
+    IOIntelligenceAsyncHTTPClient
+from langchain_iointelligence.chat import IOIntelligenceChatModel
+from langchain_iointelligence.streaming import build_generation_chunk
+
+
+def _model():
+    return IOIntelligenceChatModel(
+        api_key="k", api_url="https://test.api.com/v1/chat/completions"
+    )
+
+
+def _chat_response(content="Hello!"):
+    return {
+        "id": "r1",
+        "model": "m",
+        "choices": [
+            {"finish_reason": "stop", "message": {"role": "assistant", "content": content}}
+        ],
+        "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+    }
+
+
+async def _aiter(items):
+    for item in items:
+        yield item
+
+
+class TestRequestData:
+    def test_stream_options_added_for_streaming(self):
+        chat = _model()
+        data = chat._build_request_data([HumanMessage(content="hi")], None, stream=True)
+        assert data["stream"] is True
+        assert data["stream_options"] == {"include_usage": True}
+
+    def test_no_stream_options_for_sync(self):
+        chat = _model()
+        data = chat._build_request_data([HumanMessage(content="hi")], None)
+        assert "stream" not in data
+        assert "stream_options" not in data
+
+    def test_caller_can_override_stream_options(self):
+        chat = _model()
+        data = chat._build_request_data(
+            [HumanMessage(content="hi")], None, stream=True,
+            stream_options={"include_usage": False},
+        )
+        assert data["stream_options"] == {"include_usage": False}
+
+
+class TestAsyncGenerate:
+    def test_agenerate_parses_response(self):
+        chat = _model()
+        mock_client = AsyncMock()
+        mock_client.apost_with_retry.return_value = _chat_response("Hi async")
+        with patch.object(
+            IOIntelligenceChatModel, "async_http_client", mock_client
+        ):
+            result = asyncio.run(
+                chat._agenerate([HumanMessage(content="hello")])
+            )
+        msg = result.generations[0].message
+        assert isinstance(msg, AIMessage)
+        assert msg.content == "Hi async"
+        assert msg.usage_metadata["total_tokens"] == 5
+        mock_client.apost_with_retry.assert_awaited_once()
+
+    def test_ainvoke_end_to_end(self):
+        chat = _model()
+        mock_client = AsyncMock()
+        mock_client.apost_with_retry.return_value = _chat_response("pong")
+        with patch.object(
+            IOIntelligenceChatModel, "async_http_client", mock_client
+        ):
+            out = asyncio.run(chat.ainvoke("ping"))
+        assert out.content == "pong"
+
+
+class TestAsyncStream:
+    def test_astream_yields_content_and_usage(self):
+        chat = _model()
+        raw_chunks = [
+            {"choices": [{"delta": {"content": "Hel"}}]},
+            {"choices": [{"delta": {"content": "lo"}}]},
+            {"choices": [], "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3}},
+        ]
+
+        mock_client = AsyncMock()
+        # astream is an async generator, not a coroutine.
+        mock_client.astream = lambda data: _aiter(raw_chunks)
+
+        async def _collect():
+            chunks = []
+            async for c in chat._astream([HumanMessage(content="hi")]):
+                chunks.append(c)
+            return chunks
+
+        with patch.object(
+            IOIntelligenceChatModel, "async_http_client", mock_client
+        ):
+            chunks = asyncio.run(_collect())
+
+        text = "".join(c.message.content for c in chunks)
+        assert text == "Hello"
+        # Final chunk carries usage metadata.
+        usage_chunks = [c for c in chunks if c.message.usage_metadata]
+        assert usage_chunks
+        assert usage_chunks[-1].message.usage_metadata["total_tokens"] == 3
+
+
+class TestStreamingUsageChunk:
+    def test_usage_only_chunk(self):
+        chunk = build_generation_chunk(
+            {"usage": {"prompt_tokens": 4, "completion_tokens": 6, "total_tokens": 10}, "choices": []}
+        )
+        assert chunk is not None
+        assert chunk.message.usage_metadata["input_tokens"] == 4
+        assert chunk.message.usage_metadata["total_tokens"] == 10
+
+    def test_empty_chunk_without_usage_is_none(self):
+        assert build_generation_chunk({"choices": []}) is None
+
+
+class TestAsyncHTTPClient:
+    def _patch_httpx(self, responses):
+        """Patch httpx.AsyncClient to return queued fake responses for post()."""
+
+        class _Resp:
+            def __init__(self, status_code, json_data=None, text=""):
+                self.status_code = status_code
+                self._json = json_data
+                self.text = text
+
+            def json(self):
+                return self._json
+
+        queue = list(responses)
+
+        class _FakeClient:
+            def __init__(self, *a, **k):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def post(self, url, headers=None, json=None):
+                return queue.pop(0)
+
+        import langchain_iointelligence.async_http_client as mod
+
+        return patch.object(mod.httpx, "AsyncClient", _FakeClient), _Resp
+
+    def test_success(self):
+        patcher, Resp = self._patch_httpx([])
+        # Build response objects after we have Resp.
+        responses = [Resp(200, {"ok": True})]
+        patcher, Resp = self._patch_httpx(responses)
+        client = IOIntelligenceAsyncHTTPClient("k", "https://x", max_retries=0)
+        with patcher:
+            out = asyncio.run(client.apost_with_retry({"a": 1}))
+        assert out == {"ok": True}
+
+    def test_retries_on_server_error_then_succeeds(self):
+        _, Resp = self._patch_httpx([])
+        responses = [Resp(500, None, "boom"), Resp(200, {"ok": 1})]
+        patcher, _ = self._patch_httpx(responses)
+        client = IOIntelligenceAsyncHTTPClient(
+            "k", "https://x", max_retries=2, retry_delay=0
+        )
+        with patcher:
+            out = asyncio.run(client.apost_with_retry({"a": 1}))
+        assert out == {"ok": 1}
+
+    def test_auth_error_not_retried(self):
+        from langchain_iointelligence.exceptions import \
+            IOIntelligenceAuthenticationError
+
+        _, Resp = self._patch_httpx([])
+        responses = [Resp(401, None, "nope")]
+        patcher, _ = self._patch_httpx(responses)
+        client = IOIntelligenceAsyncHTTPClient(
+            "k", "https://x", max_retries=3, retry_delay=0
+        )
+        with patcher:
+            try:
+                asyncio.run(client.apost_with_retry({"a": 1}))
+                assert False, "expected auth error"
+            except IOIntelligenceAuthenticationError:
+                pass


### PR DESCRIPTION
## Summary

Two of the remaining LangChain integration gaps.

### ⚡ Native async
- **`async_http_client.py`** — httpx-based `IOIntelligenceAsyncHTTPClient` mirroring the sync client's retry/backoff + error classification, plus an async SSE stream.
- **`_agenerate` / `_astream`** implemented natively (true async I/O), so `ainvoke` / `astream` / `abatch` work without thread-pool wrapping — first-class in LangServe / LangGraph. Falls back to the base thread-pool behaviour if httpx is somehow unavailable.

### 📊 Streaming usage metadata
- Streaming requests now send `stream_options.include_usage`; the final usage-only SSE chunk is surfaced as a chunk carrying **`usage_metadata`** (both sync and async). Closes the prior "usage-at-end coming soon" gap.

### ♻️ Refactor + bug fix
- Extracted `_build_request_data` and `_create_chat_result` so sync/async share request building and response parsing; chunk construction moved to a shared `build_generation_chunk()`.
- **Fix:** classified API errors (auth/client/server) subclass `ValueError`, so they were being swallowed by the JSON-decode `except ValueError` handler in both the sync and async clients and re-wrapped as "Invalid JSON response". They now propagate with the correct type/message.

### Housekeeping
- New dependency **`httpx>=0.23.0`**; version **0.4.0 → 0.5.0**.
- README async/streaming docs + `examples/async_usage.py`.

## Testing
- **91 tests pass** (+11 in `tests/test_async.py`): async generate/stream, the async client's retry-on-500 / no-retry-on-401 behaviour, request building (`stream_options`), and usage chunks.
- `python -m build` + `twine check`: clean. Fresh-venv install of the 0.5.0 wheel runs `ainvoke` (mocked transport) and pulls in httpx.
- CI matrix (3.9–3.13) runs on this PR.

## Notes
- No breaking changes to existing sync/text/vision/tool APIs.
- Embeddings was evaluated but **deferred**: io Intelligence does not document an `/embeddings` endpoint, so shipping one would be speculative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)